### PR TITLE
Add missing file to source and wheel distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
-include open_alchemy/helpers/get_ext_prop/common-schemas.json
-include open_alchemy/helpers/get_ext_prop/extension-schemas.json
+recursive-include *.json
+prune docs
+prune examples
+prune tests
+remove .*

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Translates an OpenAPI schema to SQLAlchemy models.
 
 ## Installation
 ```bash
-python -m pip install OpenAlchemy
+python -m pip install OpenAlchemy[yaml]
 # To be able to load yaml file
-python -m pip install PyYAML
+python -m pip install OpenAlchemy[yaml]
 ```
 
 ## Example

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [tool:pytest]
 addopts = -v --cov=open_alchemy --cov=examples/app --cov-config=tests/.coveragerc --flake8 --strict
 flakes-ignore =

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="OpenAlchemy",
-    version="0.10.1",
+    version="0.10.2",
     author="David Andersson",
     author_email="anderssonpublic@gmail.com",
     description="Maps an OpenAPI schema to SQLAlchemy models.",
@@ -30,6 +30,9 @@ setuptools.setup(
     install_requires=["SQLAlchemy>=1.0", "typing-extensions>=3.5", "jsonschema>=3"],
     include_package_data=True,
     extras_require={
+        "yaml": [
+            "PyYAML",
+        ],
         "dev": [
             "tox",
             "tox-pyenv",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="OpenAlchemy",
-    version="0.10.2",
+    version="0.10.3",
     author="David Andersson",
     author_email="anderssonpublic@gmail.com",
     description="Maps an OpenAPI schema to SQLAlchemy models.",


### PR DESCRIPTION
Both the source and wheel distributions on PyPi are missing the
`extension-schemas.json` file.

```
FileNotFoundError: [Errno 2] No such file or directory: '.../venv/lib/python3.8/site-packages/openapi_sqlalchemy/helpers/get_ext_prop/extension-schemas.json'
````