### PR TITLE
adjust _get_properties and to_dict to respect backrefs

### DIFF
--- a/open_alchemy/utility_base.py
+++ b/open_alchemy/utility_base.py
@@ -46,7 +46,7 @@ class UtilityBase:
         return cls._schema
 
     @classmethod
-    def _get_properties(cls, include_backrefs = False) -> types.Schema:
+    def _get_properties(cls, include_backrefs: bool = False) -> types.Schema:
         """
         Get the properties from the schema.
 
@@ -65,10 +65,8 @@ class UtilityBase:
                 "The model schema does not have any properties."
             )
         backrefs = schema.get("x-backrefs")
-        if include_backrefs and backrefs is not None:
-            return {**properties, **backrefs} 
-	
-        return properties
+        return {**properties,
+                **backrefs} if include_backrefs and backrefs is not None else properties
 
     @staticmethod
     def _get_model(
@@ -363,7 +361,7 @@ class UtilityBase:
         # Handle other types
         return cls._simple_type_to_dict(format_=format_, value=value)
 
-    def to_dict(self, include_backrefs = True) -> typing.Dict[str, typing.Any]:
+    def to_dict(self, include_backrefs: bool = False) -> typing.Dict[str, typing.Any]:
         """
         Convert model instance to dictionary.
 

--- a/open_alchemy/utility_base.py
+++ b/open_alchemy/utility_base.py
@@ -65,8 +65,11 @@ class UtilityBase:
                 "The model schema does not have any properties."
             )
         backrefs = schema.get("x-backrefs")
-        return {**properties,
-                **backrefs} if include_backrefs and backrefs is not None else properties
+        return (
+            {**properties, **backrefs}
+            if include_backrefs and backrefs is not None
+            else properties
+        )
 
     @staticmethod
     def _get_model(

--- a/open_alchemy/utility_base.py
+++ b/open_alchemy/utility_base.py
@@ -225,11 +225,11 @@ class UtilityBase:
 
     @staticmethod
     def _object_to_dict_relationship(
-        *, value: typing.Any, name: str
+        *, value: typing.Any, name: str, include_backrefs: bool = False
     ) -> typing.Dict[str, typing.Any]:
         """Call to_dict on relationshup object."""
         try:
-            return value.to_dict()
+            return value.to_dict(include_backrefs=include_backrefs)
         except AttributeError:
             raise exceptions.InvalidModelInstanceError(
                 f"The {name} object property instance does not have a to_dict "
@@ -262,11 +262,18 @@ class UtilityBase:
 
     @classmethod
     def _object_to_dict(
-        cls, value, name: str, spec: types.Schema, read_only: bool
+        cls,
+        value,
+        name: str,
+        spec: types.Schema,
+        read_only: bool,
+        include_backrefs: bool = False,
     ) -> typing.Dict[str, typing.Any]:
         """Call to_dict on object."""
         if not read_only:
-            return cls._object_to_dict_relationship(value=value, name=name)
+            return cls._object_to_dict_relationship(
+                value=value, name=name, include_backrefs=include_backrefs
+            )
         return cls._object_to_dict_read_only(value=value, name=name, spec=spec)
 
     @staticmethod
@@ -302,6 +309,7 @@ class UtilityBase:
         name: str,
         array_context: bool = False,
         read_only: bool = False,
+        include_backrefs: bool = False,
     ) -> typing.Any:
         """
         Perform property level to dict operation.
@@ -348,6 +356,7 @@ class UtilityBase:
                 name=name,
                 array_context=True,
                 read_only=read_only,
+                include_backrefs=include_backrefs,
             )
             array_dict_values = map(to_dict_property, value)
             return list(array_dict_values)
@@ -358,7 +367,11 @@ class UtilityBase:
         # Handle object
         if type_ == "object":
             return cls._object_to_dict(
-                value=value, name=name, spec=spec, read_only=read_only
+                value=value,
+                name=name,
+                spec=spec,
+                read_only=read_only,
+                include_backrefs=include_backrefs,
             )
 
         # Handle other types
@@ -382,7 +395,7 @@ class UtilityBase:
         for name, spec in properties.items():
             value = getattr(self, name, None)
             return_dict[name] = self._to_dict_property(
-                spec=spec, name=name, value=value
+                spec=spec, name=name, value=value, include_backrefs=include_backrefs
             )
 
         return return_dict

--- a/open_alchemy/utility_base.py
+++ b/open_alchemy/utility_base.py
@@ -46,7 +46,7 @@ class UtilityBase:
         return cls._schema
 
     @classmethod
-    def _get_properties(cls) -> types.Schema:
+    def _get_properties(cls, include_backrefs = False) -> types.Schema:
         """
         Get the properties from the schema.
 
@@ -64,6 +64,10 @@ class UtilityBase:
             raise exceptions.MalformedSchemaError(
                 "The model schema does not have any properties."
             )
+        backrefs = schema.get("x-backrefs")
+        if include_backrefs and backrefs is not None:
+            return {**properties, **backrefs} 
+	
         return properties
 
     @staticmethod
@@ -359,7 +363,7 @@ class UtilityBase:
         # Handle other types
         return cls._simple_type_to_dict(format_=format_, value=value)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self, include_backrefs = True) -> typing.Dict[str, typing.Any]:
         """
         Convert model instance to dictionary.
 
@@ -370,7 +374,7 @@ class UtilityBase:
             The dictionary representation of the model.
 
         """
-        properties = self._get_properties()
+        properties = self._get_properties(include_backrefs=include_backrefs)
 
         # Collecting the values of the properties
         return_dict: typing.Dict[str, typing.Any] = {}

--- a/tests/open_alchemy/utility_base/test_to_dict.py
+++ b/tests/open_alchemy/utility_base/test_to_dict.py
@@ -352,7 +352,7 @@ class TestObjectToDictRelationship:
         )
 
         assert returned_value == value.to_dict.return_value
-        value.to_dict.assert_called_once_with()
+        value.to_dict.assert_called_once_with(include_backrefs=False)
 
 
 class TestObjectToDictReadOnly:


### PR DESCRIPTION
Hi,
First of all Thank you for your great project. We are currently using it in one of our Data Management APIs.

We are heavily utilizing the conversion using from_dict, and to_dict in our project. In this regard i had to find out, that if we have a property filled using backref it is not included in the dict resulting from the to_dict() method.

I had a short look into the code and saw, that this is because to_dict is relying in  _get_properties, which fetches only the explicitly set properties from the schema.

I thought this is easy to fix, as we have the backrefs already in the schema.

This PR changes the behavior. Therefore i added a flag to _get_properties if we want to include the backrefs, which defaults to False. I also added that flag to the to_dict method, where it defaults to True. 
If the flag is true it returns the merged dicts of properties and x-backrefs from the schema instead of only the properties.

I hope this makes sense, and i would be really happy to get that merged in this or a similiar way, as we need such a behavior.

Best Regards,
Shogoki
