### PR TITLE
Convert the Changelog to Keep A Changelog

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+# Disable some built-in rules.
+no-duplicate-header:
+  allow_different_nesting: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,9 @@ repos:
       - id: remove-crlf
       - id: forbid-tabs
       - id: remove-tabs
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.0.11
+    hooks:
+      - id: markdownlint-cli2
+        args: ["**/*.md"]
+        language_version: system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,113 +1,178 @@
-# Release Notes
+# Changelog
 
-## Version _next_
+All notable changes to this project will be documented in this file.
 
-- Remove `define_all` parameter for `init_model_factory`, `init_json` and
-  `init_yaml`. OpenAlchemy now behaves as though `define_all` is set to
-  `True`. _This means that a pure model reference (a schema with only the
-  `$ref` key) can no longer be used to change the name of a model._
-- Fix bug where the association table defined for `many-to-many` relationships
-  did not make the foreign key columns referencing the two sides of the
-  relationship primary keys. _This may require a database migration if alembic
-  was used to generate the database schema._
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add check enforcing unique `x-tablename` values.
+- Add check enforcing unique `x-secondary` values.
+- Add custom association schemas validation
+- Add support for custom association tables
+- Add `openalchemy` CLI with a first subcommand to build a Python package from a
+  specification file. [#201]
+- Add a CLI subcommand to regenerate models. [#202]
+
+### Changed
+
 - Change the association table to no longer be noted on the models based on
   the `x-secondary` value and instead be noted based on converting the
   `x-secondary` value from snake_case to PascalCase. Name clashes are avoided
   by pre-pending `Autogen` as many times as required.
 - Change the association table to no longer be constructed as a table and
   instead to be constructed as another model.
+- Refactor column factory to use the schemas artifacts
+
+### Fixed
+
+- Fix bug where the association table defined for `many-to-many` relationships
+  did not make the foreign key columns referencing the two sides of the
+  relationship primary keys. _This may require a database migration if alembic
+  was used to generate the database schema._
 - Fix bug where some properties were incorrectly picked from a reference even
   though they existed locally (only impacts relationship properties where, for
   example, `x-secondary` was defined both on the relationship property in
   `allOf` and on the referenced model).
-- Add check enforcing unique `x-tablename` values.
-- Add check enforcing unique `x-secondary` values.
-- Add custom association schemas validation
-- Add support for custom association tables
-- Refactor column factory to use the schemas artifacts
 
-## Version 1.5.4 - 2020-10-10
+### Removed
+
+- Remove `define_all` parameter for `init_model_factory`, `init_json` and
+  `init_yaml`. OpenAlchemy now behaves as though `define_all` is set to
+  `True`. _This means that a pure model reference (a schema with only the
+  `$ref` key) can no longer be used to change the name of a model._
+
+## [1.6.0] - 2020-10-10
+
+### Added
+
+- Add `build_json` and `build_yaml` interfaces which can be used to produce a
+  package with the models. [#190]
+- Add support for building sdist or wheel distributable archive.
+
+### Changed
 
 - Refactor the models file generation to use the artifacts from the schemas.
-- Add `build_json` and `build_yaml` interfaces which can be used to produce a
-  package with the models.
 - Changed output of build_json and build_yaml to be contained within a project
   directory.
-- Add support for building sdist or wheel distributable archive.
-- Drop support for Python 3.6 and add support for Python 3.9.
+- Drop support for Python 3.6 and add support for Python 3.9. [#198]
 
-## Version 1.5.4 - 2020-08-30
+## [1.5.4] - 2020-08-30
+
+### Changed
 
 - Move `description` to be a top level property artifact for every property.
 
-## Version 1.5.3 - 2020-08-29
+## [1.5.3] - 2020-08-29
+
+### Fixed
 
 - Correct `format` key to no longer have a trailing `_` for artifacts.
 
-## Version 1.5.2 - 2020-08-29
+## [1.5.2] - 2020-08-29
+
+### Changed
 
 - Expose function that collects artifacts for the models.
 - Expose function that collects artifacts for the model properties.
 
-## Version 1.5.1 - 2020-08-23
+## [1.5.1] - 2020-08-23
+
+### Added
 
 - Add support for arbitrary mix in classes.
 
-## Version 1.5.0 - 2020-08-22
+## [1.5.0] - 2020-08-22
+
+### Added
 
 - Add support for generic `format` for `string` that are treated like a
   `string` without a `format`.
+- Add interface to check un-managed models for the reason why they are not
+  managed.
+
+### Changed
+
 - Change constructable check to no longer check the schema of `x-tablename`
   and `x-inherits`.
 - Change schema validation to process properties even if the model is not
   valid.
-- Add interface to check un-managed models for the reason why they are not
-  managed.
 
-## Version 1.4.3 - 2020-08-16
+## [1.4.3] - 2020-08-16
+
+### Removed
 
 - Remove dependency on black
 
-## Version 1.4.2 - 2020-08-16
+## [1.4.2] - 2020-08-16
+
+### Fixed
 
 - Fix bug where iterating over constructable schemas did not handle some
   exceptions
 - Add black dependency back in
 
-## Version 1.4.1 - 2020-08-09
+## [1.4.1] - 2020-08-09
+
+### Removed
 
 - Remove black dependency
 
-## Version 1.4.0 - 2020-08-09
+## [1.4.0] - 2020-08-09
+
+### Added
 
 - Add schemas pre-processor that extracts the required back references.
 - Add foreign key pre-processor that extracts the required foreign keys.
 - Add schema validation pre-processor.
 - Add function that checks a specification.
 
-## Version 1.3.0 - 2020-07-12
+## [1.3.0] - 2020-07-12
+
+### Added
 
 - Add support for generic JSON data for properties.
 - Add support for `writeOnly`.
+
+### Fixed
+
 - Fix bug where the name of the foreign key column was based on the table name
   and not the property name.
 
-## Version 1.2.0 - 2020-06-08
+## [1.2.0] - 2020-06-08
+
+### Added
+
+- Add support for `__str__` and `__repr__` for model instances.
+
+### Changed
+
+- Ring fence `black` dependency.
+
+### Removed
 
 - Remove several bugs from the generated models file and integrate with
   `sqlalchemy-stubs`.
-- Ring fence `black` dependency.
-- add support for `__str__` and `__repr__` for model instances.
 
-## Version 1.1.1 - 2020-05-17
+## [1.1.1] - 2020-05-17
+
+### Added
 
 - Add support for `readOnly`.
+
+### Fixed
+
 - Fix bug where TypedDIct types for `binary`, `date` and `date-time` string
   formats mapped to the incorrect python types.
 - Fix bug where `to_dict` and `to_str` returned `null` for values that are not
   required and not nullable.
 
-## Version 1.1.0 - 2020-04-05
+## [1.1.0] - 2020-04-05
+
+### Added
 
 - Add section of documentation for each example.
 - Add support for keyword arguments for relationships used to define
@@ -115,71 +180,105 @@
 - Add support for kwargs at the model, column and foreign key level.
 - Add support for single and joined table inheritance.
 
-## Version 1.0.0 - 2020-03-21
+## [1.0.0] - 2020-03-21
+
+### Added
 
 - Add support for remote references to a file at a URL.
 - Add support for default values.
 - Add check for whether the value of an extension property is null.
 
-## Version 0.14.0 - 2020-02-21
+## [0.14.0] - 2020-02-21
+
+### Added
 
 - Add support for remote references to another file on the file system.
 
-## Version 0.13.0 - 2020-02-16
+## [0.13.0] - 2020-02-16
 
-- Ring fence SQLAlchemy dependency to a facade and integration tests.
+### Added
+
 - Add tests for examples.
 - Add `from_str` and `to_str` to complement `from_dict` and `to_dict` for
   de-serializing and serializing from JSON.
-- Ring fence jsonschema dependency into a facade.
 - Add description from OpenAPI specification into the models file.
 
-## Version 0.12.1 - 2020-01-12
+### Changed
+
+- Ring fence SQLAlchemy dependency to a facade and integration tests.
+- Ring fence jsonschema dependency into a facade.
+
+## [0.12.1] - 2020-01-12
+
+### Fixed
 
 - Fix bug where auto generating models file meant that multiple classes with
   the same name were registered with the base.
 
-## Version 0.12.0 - 2020-01-04
+## [0.12.0] - 2020-01-04
 
-- Fix bug where format and maxLength was not considered for the foreign key
-  constructed for an object reference.
-- Refactor object reference handling to be easier to understand.
+### Added
+
 - Add checking whether the column is automatically generated to determining
   the type of a column.
-- Remove typing_extensions dependency for Python version 3.8 and later.
 - Add support for `nullable` for object references.
 - Add type hints for `\_\_init\_\_` and `from_dict`.
 - Add example for alembic interoperability.
 
-## Version 0.11.0 - 2019-12-29
+### Changed
+
+- Refactor object reference handling to be easier to understand.
+
+### Removed
+
+- Remove typing_extensions dependency for Python version 3.8 and later.
+
+### Fixed
+
+- Fix bug where format and maxLength was not considered for the foreign key
+  constructed for an object reference.
+
+## [0.11.0] - 2019-12-29
+
+### Added
 
 - Add support for `password`
 - Add support for `binary`
 - Add support for `byte`
 - Add support for `date`
-- Move SQLAlchemy relationship construction behind facade
-- Move schema calculations into separate files
-- Refactor handling array references to reduce scope of individual tests and
-  make them easier to understand
 - Add optional parameter that can be used to generate a models file for IDE
   auto complete and type hinting
 - Add `from_dict` and `to_dict` to the type models file
 - Add SQLAlchemy information to models file
 - Add back references to models file
 
-## Version 0.10.4 - 2019-12-18
+### Changed
+
+- Move SQLAlchemy relationship construction behind facade
+- Move schema calculations into separate files
+- Refactor handling array references to reduce scope of individual tests and
+  make them easier to understand
+
+## [0.10.4] - 2019-12-18
+
+### Fixed
 
 - Fix bug where some static files where not included in the distribution.
 
-## Version 0.10.1 - 2019-12-15
+## [0.10.1] - 2019-12-15
+
+### Added
+
+- Add support for DateTime.
+
+### Changed
 
 - Refactor column handler to first check the schema, then gather the required
   artifacts for column construction and then construct the column.
-- Add support for DateTime.
 
-## Version 0.10.0 - 2019-11-23
+## [0.10.0] - 2019-11-23 [_Beta release_]
 
-_Beta release_
+### Added
 
 - Add check for whether foreign key for relationship is already constructed
   before automatically constructing it.
@@ -187,11 +286,15 @@ _Beta release_
   using `readOnly` properties.
 - Add support for many to many relationships.
 
-## Version 0.9.1 - 2019-11-11
+## [0.9.1] - 2019-11-11
+
+### Fixed
 
 - Fix bug where some static files where not included in the distribution.
 
-## Version 0.9.0 - 2019-11-10
+## [0.9.0] - 2019-11-10
+
+### Added
 
 - Add `from_dict` and `to_dict` functions to all models that are used to
   construct a model from a dictionary and to convert a model instance to a
@@ -203,74 +306,158 @@ _Beta release_
 - Add `x-composite-index` extension property at the object level to construct
   indexes with multiple columns.
 - Add support for one to one relationships.
-- Fix bug where `allOf` merging would only return the properties of the last
-  object instead of merging the properties.
 - Add support for one to many relationships.
 
-## Version 0.8.0 - 2019-11-03
+### Fixed
+
+- Fix bug where `allOf` merging would only return the properties of the last
+  object instead of merging the properties.
+
+## [0.8.0] - 2019-11-03
+
+### Added
 
 - Add less verbose initialisation with `init_yaml` and `init_json`.
-- Remove need for separate models file by exposing `Base` and constructed
-  models at `open_alchemy.models`.
+
+### Changed
+
 - Update name from OpenAPI-SQLAlchemy to OpenAlchemy
 
-## Version 0.7.0 - 2019-10-27
+### Removed
+
+- Remove need for separate models file by exposing `Base` and constructed
+  models at `open_alchemy.models`.
+
+## [0.7.0] - 2019-10-27
+
+### Added
 
 - Add support for Python 3.6.
 - Add connexion example application.
+- Add schema checking for extension properties.
+
+### Fixed
+
 - Fixed bug where referencing a schema which uses allOf in many to one
   relationships does not merge the allOf statement.
 - Fixed bug where a type hint that is not always exported from SQLAlchemy may
   cause an no member error.
-- Add schema checking for extension properties.
 
-## Version 0.6.3 - 2019-10-19
+## [0.6.3] - 2019-10-19
+
+### Added
 
 - Add support for backref for many to one relationships.
-- Refactor to remove reference resolving decorator.
 - Add integration tests for major features.
 
-## Version 0.6.2 - 2019-10-19
+### Removed
+
+- Refactor to remove reference resolving decorator.
+
+## [0.6.2] - 2019-10-19
+
+### Added
 
 - Add support for python 3.8.
 
-## Version 0.6.1 - 2019-10-19
+## [0.6.1] - 2019-10-19
+
+### Changed
 
 - Update name from openapi-SQLAlchemy to OpenAPI-SQLAlchemy. All urls are
   expected to keep working.
 
-## Version 0.6.0 - 2019-10-6
+## [0.6.0] - 2019-10-6
+
+### Added
 
 - Add support for `allOf` for models.
 
-## Version 0.5.0 - 2019-09-29
+## [0.5.0] - 2019-09-29
+
+### Added
+
+- Add support for `$ref` for models.
+
+### Changed
 
 - Refactor column factory to use fewer decorators.
 - Change exceptions to include the schema name.
-- Add support for `$ref` for models.
 
-## Version 0.4.0 - 2019-09-21
+## [0.4.0] - 2019-09-21
+
+### Added
 
 - Add support for `allOf` for columns.
 
-## Version 0.3.0 - 2019-09-08
+## [0.3.0] - 2019-09-08
+
+### Added
 
 - Add support for `autoincrement`.
 - Add support for `$ref` for columns referencing other table objects.
 - Add documentation
 
-## Version 0.2.0 - 2019-08-25
+## [0.2.0] - 2019-08-25
+
+### Added
 
 - Add support for `$ref` for columns.
 
-## Version 0.1.1 - 2019-08-18
+## [0.1.1] - 2019-08-18
+
+### Changed
 
 - Move typing-extensions development to package dependency.
 
-## Version 0.1.0 - 2019-08-18
+## [0.1.0] - 2019-08-18
 
 - Initial release
 - Add support for `integer` columns.
 - Add support for `boolean` columns.
 - Add support for `number` columns.
 - Add support for `string` columns.
+
+[//]: # "Release links"
+[0.1.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.1.0
+[0.1.1]: https://github.com/jdkandersson/OpenAlchemy/releases/0.1.1
+[0.2.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.2.0
+[0.3.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.3.0
+[0.4.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.4.0
+[0.5.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.5.0
+[0.6.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.6.0
+[0.6.1]: https://github.com/jdkandersson/OpenAlchemy/releases/0.6.1
+[0.6.2]: https://github.com/jdkandersson/OpenAlchemy/releases/0.6.2
+[0.6.3]: https://github.com/jdkandersson/OpenAlchemy/releases/0.6.3
+[0.7.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.7.0
+[0.8.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.8.0
+[0.9.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.9.0
+[0.9.1]: https://github.com/jdkandersson/OpenAlchemy/releases/0.9.1
+[0.10.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.10.0
+[0.10.1]: https://github.com/jdkandersson/OpenAlchemy/releases/0.10.1
+[0.10.4]: https://github.com/jdkandersson/OpenAlchemy/releases/0.10.4
+[0.11.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.11.0
+[0.12.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.12.0
+[0.12.1]: https://github.com/jdkandersson/OpenAlchemy/releases/0.12.1
+[0.13.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.13.0
+[0.14.0]: https://github.com/jdkandersson/OpenAlchemy/releases/0.14.0
+[1.0.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.0.0
+[1.1.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.1.0
+[1.1.1]: https://github.com/jdkandersson/OpenAlchemy/releases/1.1.1
+[1.2.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.2.0
+[1.3.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.3.0
+[1.4.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.4.0
+[1.4.1]: https://github.com/jdkandersson/OpenAlchemy/releases/1.4.1
+[1.4.2]: https://github.com/jdkandersson/OpenAlchemy/releases/1.4.2
+[1.4.3]: https://github.com/jdkandersson/OpenAlchemy/releases/1.4.3
+[1.5.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.5.0
+[1.5.1]: https://github.com/jdkandersson/OpenAlchemy/releases/1.5.1
+[1.5.2]: https://github.com/jdkandersson/OpenAlchemy/releases/1.5.2
+[1.5.3]: https://github.com/jdkandersson/OpenAlchemy/releases/1.5.3
+[1.5.4]: https://github.com/jdkandersson/OpenAlchemy/releases/1.5.4
+[1.6.0]: https://github.com/jdkandersson/OpenAlchemy/releases/1.6.0
+[//]: # "Issue/PR links"
+[#190]: https://github.com/jdkandersson/OpenAlchemy/issues/190
+[#198]: https://github.com/jdkandersson/OpenAlchemy/issues/198
+[#201]: https://github.com/jdkandersson/OpenAlchemy/issues/201
+[#202]: https://github.com/jdkandersson/OpenAlchemy/issues/202

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ used in the code (the list will evolve over time):
 - Update the readme with any significant new features
 - Update the documentation and examples, if appropriate
 - Test docstrings should use the following structure:
+
   ```Python
   """
   GIVEN <preconditions>
@@ -58,6 +59,7 @@ used in the code (the list will evolve over time):
   THEN <this outcome is expected>
   """
   ```
+
 - Separate the code for GIVEN, WHEN and THEN in tests using a single blank line
   to indicate where each piece starts
 - Functions that are intended for re-use across the code base (e.g. helper

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-![Code Quality Status](https://github.com/jdkandersson/OpenAlchemy/workflows/Code%20quality%20checks/badge.svg) ![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/anderssonpublic/anderssonpublic/1) [![Documentation Status](https://readthedocs.org/projects/openapi-sqlalchemy/badge/?version=latest)](https://openapi-sqlalchemy.readthedocs.io/en/latest/?badge=latest) ![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/jdkandersson/OpenAlchemy) ![Code Climate technical debt](https://img.shields.io/codeclimate/tech-debt/jdkandersson/OpenAlchemy) ![LGTM Grade](https://img.shields.io/lgtm/grade/python/github/jdkandersson/OpenAlchemy)
-
 # OpenAlchemy
+
+![Code Quality Status](https://github.com/jdkandersson/OpenAlchemy/workflows/Code%20quality%20checks/badge.svg)
+![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/anderssonpublic/anderssonpublic/1)
+[![Documentation Status](https://readthedocs.org/projects/openapi-sqlalchemy/badge/?version=latest)](https://openapi-sqlalchemy.readthedocs.io/en/latest/?badge=latest)
+![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/jdkandersson/OpenAlchemy)
+![Code Climate technical debt](https://img.shields.io/codeclimate/tech-debt/jdkandersson/OpenAlchemy)
+![LGTM Grade](https://img.shields.io/lgtm/grade/python/github/jdkandersson/OpenAlchemy)
 
 Translates an OpenAPI schema to SQLAlchemy models.
 
-Get started with the online editor that will guide you through using your existing OpenAPI specification to define your database schema:
+Get started with the online editor that will guide you through using your
+existing OpenAPI specification to define your database schema:
 [Online Editor](https://editor.openalchemy.io)
 
 ## Installation
@@ -91,7 +97,10 @@ from open_alchemy.models import Base
 from open_alchemy.models import Employee
 ```
 
-With the _models_filename_ parameter a file is auto generated with type hints for the SQLAlchemy models at the specified location, for example: [type hinted models example](examples/simple/models_auto.py). This adds support for IDE auto complete, for example for the model initialization:
+With the _models_filename_ parameter a file is auto generated with type hints
+for the SQLAlchemy models at the specified location, for example:
+[type hinted models example](examples/simple/models_auto.py). This adds support
+for IDE auto complete, for example for the model initialization:
 
 ![autocomplete init](examples/simple/models_autocomplete_init.png)
 
@@ -155,7 +164,8 @@ An example API has been defined using connexion and Flask here:
 - `__repr__` model methods to support the python `repr` function,
 - `to_dict` model methods to convert instances to dictionaries,
 - `readOnly` and `writeOnly` for influence the conversion to and from dictionaries,
-- exposing created models under `open_alchemy.models` removing the need for `models.py` files and
+- exposing created models under `open_alchemy.models` removing the need for
+  `models.py` files and
 - ability to mix in arbitrary classes into a model.
 
 ## Contributing


### PR DESCRIPTION
Converts the current Changelog to the
[Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format.

Drive-bys:
* Adds a new pre-commit hook to lint markdown files using
  markdownlint-cli2.
* Fixes the markdown linter violations.

Fixes jdkandersson/OpenAlchemy#193