### PR TITLE
Automate GitHub releases

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches:
       - master
@@ -11,7 +13,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  pytest:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,6 +40,8 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -v
+      - name: Test the examples
+        run: bash tests/test_examples
   staticPython:
     runs-on: ubuntu-latest
     strategy:
@@ -94,3 +98,86 @@ jobs:
         with:
           python-version: 3.9
       - uses: pre-commit/action@v2.0.0
+
+  build:
+    runs-on: ubuntu-latest
+
+    needs:
+      - pre-commit
+      - test
+      - staticNode
+      - staticPython
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - uses: actions/cache@v1
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev,test]
+      - name: Build packages
+        run: python setup.py sdist bdist_wheel
+      - name: Upload artifacts for release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v1
+        with:
+          name: wheel
+          path: dist/
+      - name: Build the documentation
+        run: |
+          cd docs
+          make html
+      - name: Upload documentation for release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v1
+        with:
+          name: docs
+          path: docs/build/html/
+
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    needs:
+      - build
+
+    env:
+      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD }}
+      TWINE_REPOSITORY: ${{ secrets.TWINE_REPOSITORY }}
+      TWINE_NON_INTERACTIVE: 1
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Get latest Changelog Entry
+        id: changelog_entry
+        uses: mindsers/changelog-reader-action@v1.1.0
+      - name: Retrieve packages
+        uses: actions/download-artifact@v1
+        with:
+          name: wheel
+          path: dist/
+      - name: Publish the release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.changelog_entry.outputs.log_entry }}
+          files: |
+            dist/*
+      - name: Publish the packages
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine upload dist/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
Automates the GitHub releases by leveraging the Keep a changelog format.
The source and wheel packages are also attached to the release and
uploaded to the PyPI.

This also builds the documentation strictly by treating warning as
errors, and run the examples to ensure none of them gets broken.

Fixes jdkandersson/OpenAlchemy#194